### PR TITLE
add shebang

### DIFF
--- a/seed.sort.py
+++ b/seed.sort.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 #
 # author: Raymond Burkholder
 #         rburkholder@quovadis.bm


### PR DESCRIPTION
Otherwise bash is used, by default, which run ImageMagick's  import interactive command on X screen.
